### PR TITLE
Update DbContextFactory to support generic TUserId parameter

### DIFF
--- a/src/Bounteous.Data.SqlServer.Tests/Bounteous.Data.SqlServer.Tests.csproj
+++ b/src/Bounteous.Data.SqlServer.Tests/Bounteous.Data.SqlServer.Tests.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bounteous.Data" Version="0.0.19" />
+        <PackageReference Include="Bounteous.Data" Version="0.0.20" />
         <PackageReference Include="coverlet.collector" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Bounteous.Data.SqlServer.Tests/Context/TestSqlServerDbContextFactory.cs
+++ b/src/Bounteous.Data.SqlServer.Tests/Context/TestSqlServerDbContextFactory.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Bounteous.Data.SqlServer.Tests.Context;
 
-public class TestSqlServerDbContextFactory : SqlServerDbContextFactory<SqlServerTestDbContext>
+public class TestSqlServerDbContextFactory : SqlServerDbContextFactory<SqlServerTestDbContext, Guid>
 {
     public TestSqlServerDbContextFactory(IConnectionBuilder connectionBuilder, IDbContextObserver observer)
         : base(connectionBuilder, observer) { }

--- a/src/Bounteous.Data.SqlServer/Bounteous.Data.SqlServer.csproj
+++ b/src/Bounteous.Data.SqlServer/Bounteous.Data.SqlServer.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="Bounteous.Core" Version="0.0.18" />
-      <PackageReference Include="Bounteous.Data" Version="0.0.19" />
+      <PackageReference Include="Bounteous.Data" Version="0.0.20" />
       <PackageReference Include="EntityFrameworkCore.NamingConventions" Version="8.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">

--- a/src/Bounteous.Data.SqlServer/SqlServerDbContextFactory.cs
+++ b/src/Bounteous.Data.SqlServer/SqlServerDbContextFactory.cs
@@ -3,15 +3,17 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Bounteous.Data.SqlServer;
 
-public abstract class SqlServerDbContextFactory<T> : DbContextFactory<T> where T : IDbContext<Guid>
+public abstract class SqlServerDbContextFactory<T, TUserId> : DbContextFactory<T, TUserId> 
+    where T : IDbContext<TUserId> 
+    where TUserId : struct
 {
-    public SqlServerDbContextFactory(IConnectionBuilder connectionBuilder, IDbContextObserver observer) 
+    protected SqlServerDbContextFactory(IConnectionBuilder connectionBuilder, IDbContextObserver observer) 
         : base(connectionBuilder, observer)
     {
     }
 
     protected override DbContextOptions ApplyOptions(bool sensitiveDataLoggingEnabled = false)
-        => new DbContextOptionsBuilder<DbContextBase<Guid>>()
+        => new DbContextOptionsBuilder<DbContextBase<TUserId>>()
             .UseSqlServer(ConnectionBuilder.AdminConnectionString,
                 sqlOptions => { sqlOptions.EnableRetryOnFailure(); })
             .EnableSensitiveDataLogging(sensitiveDataLoggingEnabled: sensitiveDataLoggingEnabled)


### PR DESCRIPTION
- Added TUserId generic parameter to SqlServerDbContextFactory
- Updated ApplyOptions to use DbContextBase<TUserId> instead of hardcoded Guid
- Updated TestSqlServerDbContextFactory to specify Guid as TUserId type
- All tests passing (9/9)