### PR TITLE
feat: add license expression metadata and dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "direct"
+    commit-message:
+      prefix: "chore(deps):"
+    pull-request-branch-name:
+      separator: "/"

--- a/src/Bounteous.Data.SqlServer.Tests/Bounteous.Data.SqlServer.Tests.csproj
+++ b/src/Bounteous.Data.SqlServer.Tests/Bounteous.Data.SqlServer.Tests.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bounteous.Data" Version="0.0.28" />
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="Bounteous.Data" Version="0.0.29" />
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -25,7 +25,7 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/Bounteous.Data.SqlServer.Tests/Bounteous.Data.SqlServer.Tests.csproj
+++ b/src/Bounteous.Data.SqlServer.Tests/Bounteous.Data.SqlServer.Tests.csproj
@@ -10,22 +10,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bounteous.Data" Version="0.0.26" />
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="Bounteous.Data" Version="0.0.28" />
+        <PackageReference Include="coverlet.collector" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="EntityFrameworkCore.NamingConventions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/Bounteous.Data.SqlServer.Tests/Domain/TestEntity.cs
+++ b/src/Bounteous.Data.SqlServer.Tests/Domain/TestEntity.cs
@@ -2,7 +2,7 @@ using Bounteous.Data.Domain.Interfaces;
 
 namespace Bounteous.Data.SqlServer.Tests.Domain;
 
-public class TestEntity : IAuditable
+public class TestEntity : IAuditable, ISoftDelete
 {
     public Guid Id { get; set; }
     public DateTime CreatedOn { get; set; }

--- a/src/Bounteous.Data.SqlServer.Tests/Domain/TestEntityLong.cs
+++ b/src/Bounteous.Data.SqlServer.Tests/Domain/TestEntityLong.cs
@@ -2,7 +2,7 @@ using Bounteous.Data.Domain.Interfaces;
 
 namespace Bounteous.Data.SqlServer.Tests.Domain;
 
-public class TestEntityLong : IAuditable<long, long>
+public class TestEntityLong : IAuditable<long, long>, ISoftDelete
 {
     public long Id { get; set; }
     public DateTime CreatedOn { get; set; }

--- a/src/Bounteous.Data.SqlServer/Bounteous.Data.SqlServer.csproj
+++ b/src/Bounteous.Data.SqlServer/Bounteous.Data.SqlServer.csproj
@@ -8,17 +8,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Bounteous.Core" Version="[0.0.18,1.0.0)" />
-      <PackageReference Include="Bounteous.Data" Version="0.0.26" />
+      <PackageReference Include="Bounteous.Core" Version="0.0.19" />
+      <PackageReference Include="Bounteous.Data" Version="0.0.28" />
       <PackageReference Include="EntityFrameworkCore.NamingConventions" Version="8.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Bounteous.Data.SqlServer/Bounteous.Data.SqlServer.csproj
+++ b/src/Bounteous.Data.SqlServer/Bounteous.Data.SqlServer.csproj
@@ -12,8 +12,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Bounteous.Core" Version="0.0.19" />
-      <PackageReference Include="Bounteous.Data" Version="0.0.28" />
+      <PackageReference Include="Bounteous.Core" Version="0.0.20" />
+      <PackageReference Include="Bounteous.Data" Version="0.0.29" />
       <PackageReference Include="EntityFrameworkCore.NamingConventions" Version="8.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">

--- a/src/Bounteous.Data.SqlServer/Bounteous.Data.SqlServer.csproj
+++ b/src/Bounteous.Data.SqlServer/Bounteous.Data.SqlServer.csproj
@@ -5,6 +5,10 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Version>0.0.17</Version>
+        <PackageId>Bounteous.Data.SqlServer</PackageId>
+        <Authors>Bounteous</Authors>
+        <Company>Xerris Inc.</Company>
+        <LicenseExpression>MIT</LicenseExpression>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Changes
- Add `<LicenseExpression>MIT</LicenseExpression>` to Bounteous.Data.SqlServer.csproj
- Add package metadata (PackageId, Authors, Company)
- Add `.github/dependabot.yml` for automated dependency updates

## Why
- Resolve false positive Aikido license warnings for this module
- Enable Dependabot to automatically update Bounteous.Core and Bounteous.Data references
- Complete NuGet package metadata for better discoverability

## Depends On
- Bounteous.Core license update (ensures transitive compliance)
- Bounteous.Data license update (ensures transitive compliance)