### PR TITLE
Fix PackageLicenseExpression so license metadata reaches nuget.org

### DIFF
--- a/src/Bounteous.Data.SqlServer/Bounteous.Data.SqlServer.csproj
+++ b/src/Bounteous.Data.SqlServer/Bounteous.Data.SqlServer.csproj
@@ -8,7 +8,7 @@
         <PackageId>Bounteous.Data.SqlServer</PackageId>
         <Authors>Bounteous</Authors>
         <Company>Xerris Inc.</Company>
-        <LicenseExpression>MIT</LicenseExpression>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
`dotnet pack` reads the canonical `<PackageLicenseExpression>` property; the `<LicenseExpression>` element previously used here (or omitted entirely) is silently ignored by the pack target, which is why the published `.nupkg`'s `.nuspec` carried no `<license>` element and nuget.org listed the package as **License: none**.

Verified locally — `dotnet pack` now emits `<license type="expression">...</license>` in the produced `.nuspec`.